### PR TITLE
Change default value for enable_network_policy to false

### DIFF
--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -152,7 +152,7 @@ variable "core_node_max_count" {
 
 variable "enable_network_policy" {
   type        = bool
-  default     = true
+  default     = false
   description = <<-EOT
   Enable kubernetes network policy enforcement.
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request!

Don't worry, these HTML comments won't render in your issue.
Feel free to delete them once you've read them :) -->

### Summary
<!-- Please describe the purpose of this PR.
Is it fixing a bug or adding a feature?

Please reference relevant issue numbers with action words to close them if relevant. -->

This PR changes the default value of the `enable_network_policy` variable in our terraform config to false and hence also replicates the default behaviour of the underlying terraform resource. I think this also follows logically that if we have a Boolean flag to enable something, then we should explicitly enable it, rather than explicitly disable it.

### What's changed?
<!-- You can use this section to go into more detail about what's changed.
We recommend using bullet points. -->

- default value of `enable_network_policy` in `terraform/gcp/variables.tf` changed to false

### What should a reviewer concentrate their feedback on?
<!-- You can use this section to request specific feedback.
We recommend using check boxes. -->

- [ ] Does this change make sense?
- [ ] Everything looks ok?
